### PR TITLE
24 20 admin dashboard links

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,5 @@
 class AdminController < ApplicationController
-  def index
+  def dashboard
     
   end
 end

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -1,0 +1,4 @@
+<h3>Admin Dashboard</h3>
+
+<%= link_to "Merchants", admin_merchants_path %>
+<%= link_to "Invoices", admin_invoices_path %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,1 +1,0 @@
-<h3>Admin Dashboard</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  get '/admin', to: 'admin#dashboard'
-  get 'admin/merchants', to: 'admin/merchants#index'
-  get 'admin/invoices', to: 'admin/invoices#index'
+  get '/admin', to: 'admin#dashboard', as: 'admin_dashboard'
+  get 'admin/merchants', to: 'admin/merchants#index', as: 'admin_merchants'
+  get 'admin/invoices', to: 'admin/invoices#index',  as: 'admin_invoices'
 
   resources :admin, only: [:index]
   resources :merchants, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/admin', to: 'admin#dashboard'
+  get 'admin/merchants', to: 'admin/merchants#index'
+  get 'admin/invoices', to: 'admin/invoices#index'
+
   resources :admin, only: [:index]
   resources :merchants, only: [] do
     resources :items, only: [:index, :show], controller: 'merchants/items'

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe "Admin Dashboard" do
 
       expect(page).to have_content("Admin Dashboard")
    end
+
+   it 'has a link to the admin merchants index' do
+      visit '/admin'
+
+      expect(page).to have_link("Merchants")
+   end
+
+    it 'has a link to the admin invoices index' do
+      visit '/admin'
+
+      expect(page).to have_link("Invoices")
+   end
   end


### PR DESCRIPTION
Couldn't use resources: routes, had to handroll them. The resources call doesn't have an option for a dashboard, which is what is actually needed. 